### PR TITLE
add nfc keys for axp-a14

### DIFF
--- a/sign/sign_generate_keys.sh
+++ b/sign/sign_generate_keys.sh
@@ -36,7 +36,7 @@ case $HASHTYPE in
 esac
 
 unset nlist
-for c in releasekey platform shared media networkstack verity sdk_sandbox bluetooth extra apps; do
+for c in releasekey platform shared media networkstack verity sdk_sandbox bluetooth extra apps nfc; do
     for k in pem key pk8 x509.pem der;do
 	if [ -f "$KEYS_DIR/${c}.${k}" ];then
 	    echo "WARNING: $KEYS_DIR/$c.${k} exists!! I WILL NOT OVERWRITE EXISTING KEYS!"


### PR DESCRIPTION
i want to ensure that nfc key pair is created for a14 building.

During the build for axp a14 (lineage-21.0) i needed nfc keys (nfc.pk8, nfc.x509.pem). this is to ensure they are acutally there.